### PR TITLE
Mark futures as optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,8 @@ setup(
         'cryptography',
         'python-dateutil',
         'requests',
-    ] + (['futures'] if sys.version_info < (3,0) else []),
+    ],
+    extras_require={
+        ':python_version=="2.7"': ['futures'],
+    },
 )


### PR DESCRIPTION
Fix how `futures` is declared from upstream at https://github.com/Azure/azure-storage-python/blob/master/setup.py#L77.

Addresses https://github.com/Azure/azure-cli/issues/3988.