### PR TITLE
Fix bug that is preventing generate-sas for table service:

### DIFF
--- a/azure/multiapi/storage/v2017_04_17/common/models.py
+++ b/azure/multiapi/storage/v2017_04_17/common/models.py
@@ -507,6 +507,7 @@ class Services(object):
         self.blob = blob or ('b' in _str)
         self.queue = queue or ('q' in _str)
         self.file = file or ('f' in _str)
+        self.table = ('t' in _str)
 
     def __or__(self, other):
         return Services(_str=str(self) + str(other))
@@ -516,6 +517,7 @@ class Services(object):
 
     def __str__(self):
         return (('b' if self.blob else '') +
+                ('t' if self.table else '') +
                 ('q' if self.queue else '') +
                 ('f' if self.file else ''))
 


### PR DESCRIPTION
az storage account generate-sas --services bt --resource-types co --permissions aclwu --expiry "2018-12-31T14:00Z" -otsv
ss=b&sp=wlacu&sv=2017-04-17&sig=w7r... -- note ss= only b, not bt.

It just failed to parse this parameter option into a proper flag.

This bug prevents creation of metrics sink of json blob type (absolutely needed for vmss autoscaling).
Workaround is to use Portal.