### PR TITLE
Fixed azure-cli/#8032, when OData type is already specified is no longer being overwritten

### DIFF
--- a/azure/multiapi/cosmosdb/v2017_04_17/table/_serialization.py
+++ b/azure/multiapi/cosmosdb/v2017_04_17/table/_serialization.py
@@ -198,8 +198,9 @@ def _convert_entity_to_json(source):
 
         # form the property node
         properties[name] = value
-        if mtype:
-            properties[name + '@odata.type'] = mtype
+        odataTypePropertyName = name + '@odata.type'
+        if mtype and odataTypePropertyName not in properties:
+            properties[odataTypePropertyName] = mtype
 
     # generate the entity_body
     return dumps(properties)


### PR DESCRIPTION
For more details please see [azure-cli/#8032](https://github.com/Azure/azure-cli/issues/8032).