### PR TITLE
Adhere to pep420 native "azure" namespace

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst
+include azure/__init__.py


### PR DESCRIPTION
The latest 0.3.5 release doesn't install any packages under the azure namespace

```
$ ls /nix/store/gznb6si2yk7kvjcpb6p5313f7sfrs5db-python3.8-azure-multiapi-storage-0.3.5/lib/python3.8/site-packages/
azure_multiapi_storage-0.3.5.dist-info
# with PR changes
$ tree -L 3 /nix/store/ynmayrv1wy4bsvh5rgymxvfjdx761acz-python3.8-azure-multiapi-storage-0.3.5/lib/python3.8/site-packages/
/nix/store/ynmayrv1wy4bsvh5rgymxvfjdx761acz-python3.8-azure-multiapi-storage-0.3.5/lib/python3.8/site-packages/
├── azure
│   └── multiapi
│       ├── cosmosdb
│       ├── storage
│       └── storagev2
└── azure_multiapi_storage-0.3.5.dist-info
    ├── direct_url.json
    ├── INSTALLER
    ├── METADATA
    ├── RECORD
    ├── top_level.txt
    └── WHEEL

6 directories, 6 files
```