### PR TITLE
Fix syntax warnings

### DIFF
--- a/azure/multiapi/cosmosdb/v2017_04_17/common/_connection.py
+++ b/azure/multiapi/cosmosdb/v2017_04_17/common/_connection.py
@@ -88,7 +88,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2015_04_05/_connection.py
+++ b/azure/multiapi/storage/v2015_04_05/_connection.py
@@ -76,7 +76,7 @@ class _ServiceParameters(object):
             if custom_domain:
                 parsed_url = urlparse(custom_domain)
                 self.primary_endpoint = parsed_url.netloc + parsed_url.path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)         

--- a/azure/multiapi/storage/v2015_04_05/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2015_04_05/blob/baseblobservice.py
@@ -919,7 +919,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and\
+        if lease_duration != -1 and\
            (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2262,7 +2262,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and\
+        if lease_duration != -1 and\
            (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         response = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2016_05_31/_connection.py
+++ b/azure/multiapi/storage/v2016_05_31/_connection.py
@@ -80,7 +80,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2016_05_31/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2016_05_31/blob/_upload_chunking.py
@@ -366,7 +366,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer

--- a/azure/multiapi/storage/v2016_05_31/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2016_05_31/blob/baseblobservice.py
@@ -972,7 +972,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and\
+        if lease_duration != -1 and\
            (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2524,7 +2524,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and\
+        if lease_duration != -1 and\
            (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2017_04_17/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2017_04_17/blob/_upload_chunking.py
@@ -388,7 +388,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer and update position

--- a/azure/multiapi/storage/v2017_04_17/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2017_04_17/blob/baseblobservice.py
@@ -974,7 +974,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2527,7 +2527,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2017_04_17/common/_connection.py
+++ b/azure/multiapi/storage/v2017_04_17/common/_connection.py
@@ -84,7 +84,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2017_07_29/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2017_07_29/blob/_upload_chunking.py
@@ -389,7 +389,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer and update position

--- a/azure/multiapi/storage/v2017_07_29/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2017_07_29/blob/baseblobservice.py
@@ -993,7 +993,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2563,7 +2563,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2017_07_29/common/_connection.py
+++ b/azure/multiapi/storage/v2017_07_29/common/_connection.py
@@ -76,7 +76,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2017_11_09/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2017_11_09/blob/_upload_chunking.py
@@ -389,7 +389,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer and update position

--- a/azure/multiapi/storage/v2017_11_09/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2017_11_09/blob/baseblobservice.py
@@ -1000,7 +1000,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2570,7 +2570,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2017_11_09/common/_connection.py
+++ b/azure/multiapi/storage/v2017_11_09/common/_connection.py
@@ -78,7 +78,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2018_03_28/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2018_03_28/blob/_upload_chunking.py
@@ -400,7 +400,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer and update position

--- a/azure/multiapi/storage/v2018_03_28/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2018_03_28/blob/baseblobservice.py
@@ -1005,7 +1005,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2604,7 +2604,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2018_03_28/common/_connection.py
+++ b/azure/multiapi/storage/v2018_03_28/common/_connection.py
@@ -78,7 +78,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)

--- a/azure/multiapi/storage/v2018_11_09/blob/_upload_chunking.py
+++ b/azure/multiapi/storage/v2018_11_09/blob/_upload_chunking.py
@@ -400,7 +400,7 @@ class _SubStream(IOBase):
             n = self._length - self._position
 
         # return fast
-        if n is 0 or self._buffer.closed:
+        if n == 0 or self._buffer.closed:
             return b''
 
         # attempt first read from the read buffer and update position

--- a/azure/multiapi/storage/v2018_11_09/blob/baseblobservice.py
+++ b/azure/multiapi/storage/v2018_11_09/blob/baseblobservice.py
@@ -1060,7 +1060,7 @@ class BaseBlobService(StorageClient):
         :return: str
         '''
         _validate_not_none('lease_duration', lease_duration)
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
 
@@ -2716,7 +2716,7 @@ class BaseBlobService(StorageClient):
         '''
         _validate_not_none('lease_duration', lease_duration)
 
-        if lease_duration is not -1 and \
+        if lease_duration != -1 and \
                 (lease_duration < 15 or lease_duration > 60):
             raise ValueError(_ERROR_INVALID_LEASE_DURATION)
         lease = self._lease_blob_impl(container_name,

--- a/azure/multiapi/storage/v2018_11_09/common/_connection.py
+++ b/azure/multiapi/storage/v2018_11_09/common/_connection.py
@@ -79,7 +79,7 @@ class _ServiceParameters(object):
                 path = parsed_url.path.rstrip('/')
 
                 self.primary_endpoint = parsed_url.netloc + path
-                self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
+                self.protocol = self.protocol if parsed_url.scheme == '' else parsed_url.scheme
             else:
                 if not self.account_name:
                     raise ValueError(_ERROR_STORAGE_MISSING_INFO)


### PR DESCRIPTION
azure/multiapi/storage/v2015_04_05/blob/baseblobservice.py:922: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2015_04_05/blob/baseblobservice.py:2265: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2015_04_05/_connection.py:79: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_04_17/common/_connection.py:87: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_04_17/blob/_upload_chunking.py:391: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_04_17/blob/baseblobservice.py:977: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2017_04_17/blob/baseblobservice.py:2530: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2016_05_31/blob/_upload_chunking.py:369: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2016_05_31/blob/baseblobservice.py:975: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2016_05_31/blob/baseblobservice.py:2527: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2016_05_31/_connection.py:83: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_07_29/common/_connection.py:79: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_07_29/blob/_upload_chunking.py:392: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_07_29/blob/baseblobservice.py:996: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2017_07_29/blob/baseblobservice.py:2566: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2018_03_28/common/_connection.py:81: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2018_03_28/blob/_upload_chunking.py:403: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2018_03_28/blob/baseblobservice.py:1008: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2018_03_28/blob/baseblobservice.py:2607: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2017_11_09/common/_connection.py:81: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_11_09/blob/_upload_chunking.py:392: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2017_11_09/blob/baseblobservice.py:1003: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2017_11_09/blob/baseblobservice.py:2573: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2018_11_09/common/_connection.py:82: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2018_11_09/blob/_upload_chunking.py:403: SyntaxWarning: "is" with a literal. Did you mean "=="?
azure/multiapi/storage/v2018_11_09/blob/baseblobservice.py:1063: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/storage/v2018_11_09/blob/baseblobservice.py:2719: SyntaxWarning: "is not" with a literal. Did you mean "!="?
azure/multiapi/cosmosdb/v2017_04_17/common/_connection.py:91: SyntaxWarning: "is" with a literal. Did you mean "=="?