### PR TITLE
{CI} Migrate pipeline to new organization azclitools

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     timeoutInMinutes: 10
 
     pool:
-      vmImage: 'ubuntu-latest'
+      name: 'pool-ubuntu-2004'
     strategy:
       matrix:
         Python37:
@@ -40,7 +40,7 @@ jobs:
   - job: BuildPythonWheel
     condition: succeeded()
     pool:
-      vmImage: 'ubuntu-latest'
+      name: 'pool-ubuntu-2004'
     steps:
       - task: UsePythonVersion@0
         displayName: Use Python 3.7


### PR DESCRIPTION
Migrate pipeline to azclitools org.

[Build pipeline](https://dev.azure.com/azclitools/public/_build/index?definitionId=63)
[Release pipeline](https://dev.azure.com/azclitools/release/_release?view=all&_a=releases&definitionId=11)