### PR TITLE
Exclude policies.py as library code

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,4 @@
+path_classifiers:
+  library:
+    # Classify policies.py files as library code
+    - "azure/multiapi/storagev2/**/policies.py"


### PR DESCRIPTION
This PR adds `CodeQL.yaml` to exclude some files as library code